### PR TITLE
fix: redux devtools extentions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,9 @@ const store = createStore(rootReducer, compose(
   applyMiddleware(
     thunk, forbiddenWordsMiddleware, saga
   ),
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+  window.__REDUX_DEVTOOLS_EXTENSION__
+        ? window.__REDUX_DEVTOOLS_EXTENSION__()
+        : f => f
 ))
 
 saga.run(sagaWatcher)


### PR DESCRIPTION
On new version of redux devtools extention need to change this " window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__() " to this "window.__REDUX_DEVTOOLS_EXTENSION__
        ? window.__REDUX_DEVTOOLS_EXTENSION__()
        : f => f"
current version:
![Screenshot_13](https://user-images.githubusercontent.com/67759183/103481260-dc619200-4dea-11eb-9ab3-ae481830f135.jpg)
new version: 
![Screenshot_14](https://user-images.githubusercontent.com/67759183/103481306-2ba7c280-4deb-11eb-8fff-0e44cdd33725.jpg)
